### PR TITLE
Added date template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ If no custom local_root is specified:
 * Uses a default jrnl.md template
 * Organizes notes in a daily/YYYY/MM/YYYY-MM-DD.md structure
 
+### Template placeholders
+
+Templates support dynamic date and time placeholders. Use `{{%...}}` with the
+desired format string and it will be replaced when a note is created.
+
+```markdown
+# Journal for {{%YYYY-mm-dd}}
+Created at {{%HH:%M}} ({{%A}})
+```
+
+Common patterns are translated to their `strftime` equivalents. The following
+named shortcuts are also provided:
+
+* `{{%DATE}}` → `2024-03-14`
+* `{{%TIME}}` → `21:45`
+* `{{%DATETIME}}` → `2024-03-14 21:45`
+
+For minutes and other advanced tokens you can still embed `strftime` specifiers,
+e.g. `{{%HH:%M}}`. Any unknown pattern is left untouched so templates remain
+readable.
+
 ## LICENSE
 
 MIT
@@ -83,4 +104,3 @@ MIT
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
-

--- a/doc/today.txt
+++ b/doc/today.txt
@@ -9,6 +9,7 @@ CONTENTS                                                        *today-contents*
     4. Usage ....................... |today-usage|
     5. Commands .................... |today-commands|
     6. Mappings .................... |today-mappings|
+    7. Templates ................... |today-templates|
 
 ==============================================================================
 1. INTRODUCTION                                             *today-introduction*
@@ -85,4 +86,23 @@ With this mapping:
     5<leader>t  " Opens the note from 5 days ago
 
 ==============================================================================
+
+7. TEMPLATES                                                   *today-templates*
+Templates may contain placeholders of the form `{{%...}}`. When a new note is
+created each placeholder is expanded against the target date.
+Example:
+>
+    # Journal for {{%YYYY-mm-dd}}
+    Started at {{%HH:%M}} on {{%A}}
+The plugin understands common tokens like `YYYY`, `MM`, `DD`, `HH`, and `mm`
+and translates them to the appropriate |strftime()| directives. Named helpers
+are also available:
+    `{{%DATE}}`      →  `YYYY-MM-DD`
+    `{{%TIME}}`      →  `HH:MM`
+    `{{%DATETIME}}`  →  `YYYY-MM-DD HH:MM`
+You can mix in raw |strftime()| directives if you need something more specific:
+for example `{{%HH:%M}}` keeps the `%M` minute specifier untouched. Unrecognised
+patterns are left as-is so templates stay readable.
+==============================================================================
+
 vim:ft=help:et:ts=2:sw=2:sts=2:norl

--- a/lua/today/init.lua
+++ b/lua/today/init.lua
@@ -5,6 +5,125 @@ local config = {
   template = "jrnl.md"
 }
 
+local function trim(s)
+  return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function convert_format_token(format)
+  -- Map high-level template token to Lua strftime equivalent.
+  if format == "" then
+    return ""
+  end
+
+  local named_formats = {
+    DATE = "%Y-%m-%d",
+    TIME = "%H:%M",
+    DATETIME = "%Y-%m-%d %H:%M",
+  }
+
+  local upper = format:upper()
+  if named_formats[upper] then
+    return named_formats[upper]
+  end
+
+  -- Replace common journaling shorthands with the matching strftime directives.
+  local tokens = {
+    { "YYYY", "%Y" },
+    { "yyyy", "%Y" },
+    { "YY", "%y" },
+    { "yy", "%y" },
+    { "MMMM", "%B" },
+    { "mmmm", "%B" },
+    { "MMM", "%b" },
+    { "mmm", "%b" },
+    { "MM", "%m" },
+    { "mm", "%m" },
+    { "DDDD", "%A" },
+    { "dddd", "%A" },
+    { "DDD", "%a" },
+    { "ddd", "%a" },
+    { "DD", "%d" },
+    { "dd", "%d" },
+    { "HH", "%H" },
+    { "hh", "%I" },
+    { "H", "%H" },
+    { "h", "%I" },
+    { "ss", "%S" },
+    { "SS", "%S" },
+    { "s", "%S" },
+    { "A", "%p" },
+    { "a", "%p" }
+  }
+
+  local i = 1
+  local len = #format
+  local result = {}
+
+  while i <= len do
+    local handled = false
+    local char = format:sub(i, i)
+
+    -- Pass through explicit strftime escapes unchanged.
+    if char == "%" then
+      local next_char = format:sub(i + 1, i + 1)
+      if next_char ~= "" then
+        table.insert(result, "%" .. next_char)
+        i = i + 2
+      else
+        table.insert(result, "%")
+        i = i + 1
+      end
+      handled = true
+    else
+      for _, token in ipairs(tokens) do
+        local key, replacement = token[1], token[2]
+        local token_len = #key
+        if token_len > 0 and format:sub(i, i + token_len - 1) == key then
+          table.insert(result, replacement)
+          i = i + token_len
+          handled = true
+          break
+        end
+      end
+    end
+
+    if not handled then
+      table.insert(result, char)
+      i = i + 1
+    end
+  end
+
+  return table.concat(result)
+end
+
+local function expand_template(template_path, target_time)
+  -- Read the template into memory; failure falls back to a raw copy.
+  local ok, lines = pcall(vim.fn.readfile, template_path)
+  if not ok then
+    return nil, "Failed to read template: " .. (lines or "")
+  end
+
+  local content = table.concat(lines, "\n")
+  local processed = content:gsub("{{(%%.-)}}", function(match)
+    -- Strip the leading % and replace supported tokens; unknown formats are left intact.
+    local clean = trim(match:sub(2))
+    if clean == "" then
+      return match
+    end
+
+    local converted = convert_format_token(clean)
+    local ok_date, formatted = pcall(os.date, converted, target_time)
+
+    if ok_date and formatted then
+      return formatted
+    end
+
+    return match
+  end)
+
+  return vim.split(processed, "\n", { plain = true })
+end
+
 local function ensure_default_setup()
   if not config.local_root then
     local home = os.getenv("HOME")
@@ -54,7 +173,15 @@ local function today(offset)
   -- local f = io.open(file, "r")
   if vim.fn.filereadable(file) == 0 then
     local template_path = config.local_root .. "/" .. config.template
-    vim.fn.system(string.format("cp %s %s", template_path, file))
+
+    -- Expand placeholders before writing; keep the original template if expansion fails.
+    local expanded, err = expand_template(template_path, target_time)
+    if not expanded then
+      vim.notify(err, vim.log.levels.WARN)
+      vim.fn.system(string.format("cp %s %s", template_path, file))
+    else
+      vim.fn.writefile(expanded, file)
+    end
     -- os.execute(string.format("cp %s %s", template_path, file))
     -- else
     -- f:close()

--- a/lua/today/jrnl.md
+++ b/lua/today/jrnl.md
@@ -1,4 +1,4 @@
-# Date
+# {{%DATE}}
 
 ## To do
 


### PR DESCRIPTION
Great and simple daily notes plugin. This pull request extends it slightly by adding date template variables, to reduce the need for manually naming headers every time a new file is made.

Variables are included as `{{%...}}`, and match the standard strftime formats. I added a couple of extra named formats as helpers, `DATE`, `TIME`, and `DATETIME`.